### PR TITLE
Use pip --user and ANSI color codes instead of termcolor

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ other reasons? Fine, fine.. some real reasons.This is specifically made for dotf
 dotfile repository setup, and more!
 
 ## Install Guide
-1. `sudo pip install (--user) sequestrum`
+1. `pip install sequestrum --user`
 2. Leave a star on this repo
 3. Enjoy!
 

--- a/sequestrum/loggingModule.py
+++ b/sequestrum/loggingModule.py
@@ -1,32 +1,29 @@
 # Logging module
 
 import sys
-from termcolor import cprint
-
 
 def formatOutput(errorType, errorMessage, pkgName=None):
-    if pkgName is not None and pkgName is not "":
+    if pkgName:
         return("[{}:{}] {}".format(errorType, pkgName, errorMessage))
     else:
         return("[{}] {}".format(errorType, errorMessage))
 
 
-def printFatal(errorMessage, pkgName=None):
-    cprint(formatOutput("FATAL", errorMessage, pkgName), 'red')
+def printFatal(errorMessage, pkgname=None):
+    print("\033[1;31mFATAL\033[0m: {} {}".format(errorMessage, pkgName))
     sys.exit()
 
 
 def printError(errorMessage, pkgName=None):
-    cprint(formatOutput("ERROR", errorMessage, pkgName), 'red')
+    print("\033[1;31mERROR\033[0m: {} {}".format(errorMessage, pkgName))
 
 
 def printWarn(errorMessage, pkgName=None):
-    cprint(formatOutput("WARN", errorMessage, pkgName), 'yellow')
-
+    print("\033[1;33mWARN\033[0m: {} {}".format(errorMessage, pkgName))
 
 def printInfo(errorMessage, pkgName=None):
-    cprint(formatOutput("INFO", errorMessage, pkgName), 'green')
+    print("\033[1;32mINFO\033[0m: {} {}".format(errorMessage, pkgName))
 
 
 def printVerbose(errorMessage, pkgName=None):
-    cprint(formatOutput("VERBOSE", errorMessage, pkgName), 'green')
+    print("\033[1;32mVERBOSE\033[0m: {} {}".format(errorMessage, pkgName))

--- a/sequestrum/sequestrum.py
+++ b/sequestrum/sequestrum.py
@@ -37,6 +37,7 @@ def setupPackage(packageKey, configDict, dotfilePath):
     pkgName = pkgConfig['pkgName']
     newPackagePath = dotfilePath + pkgConfig['directoryName'] + "/"
     if dirMod.isFolder(newPackagePath) == False:
+        logMod.printWarn("{} does not exists. Creating the directory".format(newPackagePath))
         dirMod.createFolder(newPackagePath, pkgName)
 
     for link in pkgConfig['links']:
@@ -52,10 +53,14 @@ def setupPackage(packageKey, configDict, dotfilePath):
 
             # Setup
             if dirMod.isFolder(sourceFile):
+                logMod.printVerbose("symlinking {} to {}".format(sourceFile, destFile))
                 symMod.copyFolder(sourceFile, destFile)
+                logMod.printVerbose("deleting {}".format(sourceFile))
                 dirMod.deleteFolder(sourceFile)
             elif dirMod.isFile(sourceFile):
+                logMod.printVerbose("symlinking {} to {}".format(sourceFile, destFile))
                 symMod.copyFile(sourceFile, destFile)
+                logMod.printVerbose("deleting {}".format(sourceFile))
                 dirMod.deleteFile(sourceFile)
             else:
                 return False
@@ -159,7 +164,7 @@ def checkSourceLocations(packageKey, configDict, dotfilePath):
             sourcePath = directoryPath + key
 
             if symMod.symlinkSourceExists(sourcePath):
-                logMod.printFatal("File dosent exists: {}".format(sourcePath))
+                logMod.printFatal("File doesnt exists: {}".format(sourcePath))
 
 
 def main():
@@ -177,7 +182,7 @@ def main():
         print(errMod.formatError("Core", "No configuration found."))
         sys.exit()
 
-    configDict = yaml.load(configFile)
+    configDict = yaml.safe_load(configFile)
     packageList = []
 
     # Grab list of directories from the config.

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,7 @@ setup(
     license='MIT',
     packages=['sequestrum'],
     install_requires=[
-        'pyyaml == 3.13',
-        'termcolor == 1.1.0'
+        'pyyaml == 3.13'
     ],
     entry_points={
     'console_scripts':


### PR DESCRIPTION
The title pretty much sums up everything. But to elaborate, using `sudo pip package` breaks the distro's package manager by conflicting with the files the package manager manages. I've done this before and it lead to broken updates.

Usage of ANSI color codes is better because:
1. It doesn't depend on any external package
2. It is more portable and the code is more self-contained
3. As a bonus, it follows the terminal's colorscheme which might be a plus for someone who loves eye candies